### PR TITLE
[#6] Feat : 해외 특허 인덱스 검색기능 구현

### DIFF
--- a/src/main/java/com/example/hellopatent/config/EsProperties.java
+++ b/src/main/java/com/example/hellopatent/config/EsProperties.java
@@ -20,7 +20,19 @@ public class EsProperties {
         return new HttpHost(host, port, "http");
     }
 
-    public String getPatentIndexName() {
+    public String getkrPatentIndexName() {
+        return Optional.ofNullable(indices).map(Indices::getKr_patentsIndexName).orElse(null);
+    }
+
+    public String getenPatentIndexName() {
+        return Optional.ofNullable(indices).map(Indices::getEn_patentsIndexName).orElse(null);
+    }
+
+    public String getnotenPatentIndexName() {
+        return Optional.ofNullable(indices).map(Indices::getNoten_patentsIndexName).orElse(null);
+    }
+
+    public String getjpPatentIndexName() {
         return Optional.ofNullable(indices).map(Indices::getPatentsIndexName).orElse(null);
     }
 
@@ -33,6 +45,11 @@ public class EsProperties {
     @Setter
     public static class Indices {
         String patentsIndexName;
+        String kr_patentsIndexName;
+        String jp_patentsIndexName;
+        String en_patentsIndexName;
+        String noten_patentsIndexName;
+
         String testIndexName;
     }
 

--- a/src/main/java/com/example/hellopatent/controller/DocumentController.java
+++ b/src/main/java/com/example/hellopatent/controller/DocumentController.java
@@ -3,13 +3,12 @@ package com.example.hellopatent.controller;
 import com.example.hellopatent.dto.SearchRequestDto;
 import com.example.hellopatent.service.DocumentService;
 import lombok.RequiredArgsConstructor;
-import org.elasticsearch.action.index.IndexResponse;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,33 +16,6 @@ public class DocumentController {
 
     private final DocumentService documentService;
 
-    /**
-     * 도큐먼트 스크립트에 따른 검색 API
-     * @return
-     * @throws IOException
-     */
-
-    @GetMapping("/search")
-    public List<Map<String,Object>> getSearch() throws IOException {
-        return documentService.getSearch();
-    }
-
-    /**
-     * 도큐먼트 생성 API
-     * @return
-     * @throws IOException
-     */
-
-    /**
-     * 아이디로 도큐먼트 검색 API
-     * @param id : 도큐먼트 아이디
-     * @return
-     * @throws IOException
-     */
-    @GetMapping("/{id}")
-    public Map<String, Object> getDocument(@PathVariable String id) throws IOException {
-        return documentService.getDocument(id);
-    }
 
     @GetMapping("/patent/korean")
     public List<Map<String,Object>> getKrPatent( SearchRequestDto requestDto) throws IOException {
@@ -55,61 +27,6 @@ public class DocumentController {
             return documentService.getEnPatent(requestDto);
     }
 
-
-
-    /**
-     * 아이디로 도큐먼트 삭제 API
-     * @param id : 도큐먼트 아이디
-     * @return
-     * @throws IOException
-     */
-//    @DeleteMapping("/{id}")
-//    public DeleteResponse deleteDocument(@PathVariable String id) throws IOException {
-//        return documentService.deleteDocument(id);
-//    }
-
-    /**
-     * script 를 사용한 도큐먼트 수정 API
-     * @param id
-     * @return
-     * @throws IOException
-     */
-//    @PutMapping("/{id}/script")
-//    public UpdateResponse updateDocumentByScript(@PathVariable String id) throws IOException {
-//        return documentService.updateDocumentByScript(id);
-//    }
-
-    /**
-     * 도큐먼트 수정 API
-     * @param id
-     * @return
-     * @throws IOException
-     */
-//    @PutMapping("/{id}")
-//    public UpdateResponse updateDocument(@PathVariable String id) throws IOException {
-//        return documentService.updateDocument(id);
-//    }
-
-    /**
-     * 도큐먼트 upsert API (도큐먼트가 있는 경우 insert, 없는 경우 update)
-     * @param id
-     * @return
-     * @throws IOException
-     */
-//    @PutMapping("/{id}/upsert")
-//    public UpdateResponse upsertDocument(@PathVariable String id) throws IOException {
-//        return documentService.upsertDocument(id);
-//    }
-
-    /**
-     * 도큐먼트 bulk insert API
-     * @return
-     * @throws IOException
-     */
-//    @PostMapping("/bulk")
-//    public BulkResponse createDocumentBulk() throws IOException {
-//        return documentService.createDocumentBulk();
-//    }
 
 
 }

--- a/src/main/java/com/example/hellopatent/controller/DocumentController.java
+++ b/src/main/java/com/example/hellopatent/controller/DocumentController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @RestController
-@RequestMapping("/api/document")
 @RequiredArgsConstructor
 public class DocumentController {
 
@@ -33,10 +33,6 @@ public class DocumentController {
      * @return
      * @throws IOException
      */
-    @PostMapping
-    public IndexResponse createDocument() throws IOException {
-        return documentService.createDocument();
-    }
 
     /**
      * 아이디로 도큐먼트 검색 API
@@ -49,9 +45,14 @@ public class DocumentController {
         return documentService.getDocument(id);
     }
 
-    @GetMapping("/custom")
-    public List<Map<String,Object>> getCustom( SearchRequestDto requestDto) throws IOException {
-        return documentService.getCustom(requestDto);
+    @GetMapping("/patent/korean")
+    public List<Map<String,Object>> getKrPatent( SearchRequestDto requestDto) throws IOException {
+            return documentService.getKrPatent(requestDto);
+    }
+
+    @GetMapping("/patent/foreign")
+    public List<Map<String,Object>> getEnPatent( SearchRequestDto requestDto) throws IOException {
+            return documentService.getEnPatent(requestDto);
     }
 
 

--- a/src/main/java/com/example/hellopatent/dto/SearchRequestDto.java
+++ b/src/main/java/com/example/hellopatent/dto/SearchRequestDto.java
@@ -17,5 +17,11 @@ public class SearchRequestDto {
 
     private String[] statusType;
 
+    private String sortType;
+
+    private int page = 0;
+
     private String patentType;
+
+    private String[] country;
 }

--- a/src/main/java/com/example/hellopatent/service/DocumentService.java
+++ b/src/main/java/com/example/hellopatent/service/DocumentService.java
@@ -1,21 +1,18 @@
 package com.example.hellopatent.service;
 
 import com.example.hellopatent.dto.SearchRequestDto;
-import org.elasticsearch.action.index.IndexResponse;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 public interface DocumentService {
-//    List<String> getSearch() throws IOException;
-    IndexResponse createDocument() throws IOException;
+    // 필드별 조회
+    List<Map<String, Object>> getEnPatent(SearchRequestDto requestDto) throws IOException;
 
-    List<Map<String,Object>> getCustom(SearchRequestDto requestDto) throws IOException;
+    //    List<String> getSearch() throws IOException;
+    List<Map<String,Object>> getKrPatent(SearchRequestDto requestDto) throws IOException;
 
-    Map<String, Object> getDocument(String id) throws IOException;
-
-    List<Map<String,Object>> getSearch() throws IOException;
 
 
 

--- a/src/main/java/com/example/hellopatent/service/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/example/hellopatent/service/impl/DocumentServiceImpl.java
@@ -1,30 +1,30 @@
 package com.example.hellopatent.service.impl;
 
-import com.example.hellopatent.dto.SearchRequestDto;
-import org.elasticsearch.action.search.SearchRequest;
 import com.example.hellopatent.config.EsProperties;
+import com.example.hellopatent.dto.SearchRequestDto;
 import com.example.hellopatent.service.DocumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 @Slf4j
 @Service
@@ -33,30 +33,131 @@ public class DocumentServiceImpl implements DocumentService {
     private final RestHighLevelClient client;
     private final EsProperties esProperties;
 
-    private static final String APPLICATION_NUMBER = "application_number";
-    private static final String APPLICATION_DATE = "application_date";
-    private static final String INVENTION_TITLE = "invention_title";
-    private static final String APPLICANT = "applicant";
-    private static final String IPC_NUMBER = "ipc_number";
-    private static final String CPC_NUMBER = "cpc_number";
-    private static final String NOTICE_NUMBER = "notice_number";
-    private static final String PUBLICATION_NUMBER = "publication_number";
-    private static final String REGISTRATION_NUMBER = "registration_number";
-    private static final String LEGAL_STATUS = "legal_status";
-    private static final String SUMMARY = "summary";
+    private BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
 
-    @Override // 전체 조회
-    public List<Map<String, Object>> getSearch() throws IOException {
 
-        SearchRequest searchRequest = new SearchRequest(esProperties.getPatentIndexName());
+
+    @Override // 국내 조회
+    public List<Map<String, Object>> getKrPatent(SearchRequestDto requestDto) throws IOException {
+
+        SearchRequest searchRequest = new SearchRequest(esProperties.getkrPatentIndexName());
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.size(500);
+        //제외방식 중첩?
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
 
+        //should용
+        BoolQueryBuilder boolQueryBuilder1 = new BoolQueryBuilder();
+
+        for (int i = 0; i < requestDto.getContentType().length; i++) {
+
+            // contentType=전체 contentValue=전기,반도체
+            // &exceptType=발명의명칭&exceptValue=전자
+
+            boolean isNum = Objects.equals(requestDto.getContentType()[i], "번호정보");
+            boolean isAll = Objects.equals(requestDto.getContentType()[i], "전체");
+            boolean isPc = Objects.equals(requestDto.getContentType()[i], "IPC/CPC분류");
+            boolean isYear = Objects.equals(requestDto.getContentType()[i], "연도");
+            boolean isName = Objects.equals(requestDto.getContentType()[i], "발명의명칭");
+            boolean isSummary = Objects.equals(requestDto.getContentType()[i], "요약");
+
+
+            if (isNum) {
+                boolQueryBuilder.must(QueryBuilders.multiMatchQuery(
+                        requestDto.getContentValue()[i], "출원번호", "공개번호", "공고번호", "등록번호"));
+            } else if (isAll) {
+                boolQueryBuilder
+                        .should(QueryBuilders.matchQuery("출원인",requestDto.getContentValue()[i]).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("요약.lblank",requestDto.getContentValue()[i]).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("요약",requestDto.getContentValue()[i]).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("발명의명칭.lblank",requestDto.getContentValue()[i]).boost(3.0f).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("발명의명칭.nori",requestDto.getContentValue()[i]).boost(3.0f).fuzziness(Fuzziness.ONE))
+
+                        .should(QueryBuilders.matchQuery("발명의명칭.nori",requestDto.getContentValue()[i]))
+                        .should(QueryBuilders.matchQuery("발명의명칭.ngram",requestDto.getContentValue()[i]).boost(8.0f))
+                        .should(QueryBuilders.matchQuery("요약.nori",requestDto.getContentValue()[i]));
+
+            }else if (isPc) {
+                boolQueryBuilder.must(QueryBuilders.moreLikeThisQuery(new String[]{"IPC분류", "CPC분류"},
+                        new String[]{requestDto.getContentValue()[i]}, null).minDocFreq(1).minTermFreq(1));
+            }else if (isYear) {
+                boolQueryBuilder.must(QueryBuilders.matchQuery(
+                        "출원일자",requestDto.getContentValue()[i]));
+            }
+            else if (isName) {
+                boolQueryBuilder1
+                        .should(QueryBuilders.matchQuery("발명의명칭.lblank",requestDto.getContentValue()[i]).boost(3.0f).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("발명의명칭.nori",requestDto.getContentValue()[i]).boost(3.0f).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("발명의명칭.nori",requestDto.getContentValue()[i]))
+                        .should(QueryBuilders.matchQuery("발명의명칭.ngram",requestDto.getContentValue()[i]).boost(8.0f));
+            }
+
+            else if (isSummary) {
+                boolQueryBuilder1
+                        .should(QueryBuilders.matchQuery("요약",requestDto.getContentValue()[i]).fuzziness(Fuzziness.ONE))
+                        .should(QueryBuilders.matchQuery("요약.nori",requestDto.getContentValue()[i]));
+            }
+            else {
+                boolQueryBuilder.must(QueryBuilders.matchQuery(
+                        requestDto.getContentType()[i],  requestDto.getContentValue()[i]));
+            }
+        }
+
+
+        if (requestDto.getExceptType() != null) {
+            for (int z = 0; z < requestDto.getExceptType().length; z++) {
+                boolean isENum = Objects.equals(requestDto.getExceptType()[z], "번호정보");
+                boolean isEAll = Objects.equals(requestDto.getExceptType()[z], "전체");
+                boolean isPc = Objects.equals(requestDto.getExceptType()[z], "IPC/CPC분류");
+                boolean isYear = Objects.equals(requestDto.getExceptType()[z], "연도");
+                if (isENum) {
+                    boolQueryBuilder.mustNot(QueryBuilders.multiMatchQuery(
+                            requestDto.getExceptValue()[z], "출원번호", "공개번호", "공고번호", "등록번호"));
+                } else if (isEAll) {
+                    boolQueryBuilder.mustNot(QueryBuilders.multiMatchQuery(
+                            requestDto.getExceptValue()[z], "*"));
+                }else if (isPc) {
+                    boolQueryBuilder.mustNot(QueryBuilders.multiMatchQuery(
+                            requestDto.getExceptValue()[z], "IPC분류", "CPC분류"));
+                }else if (isYear) {
+                    boolQueryBuilder.mustNot(QueryBuilders.matchQuery(
+                            "출원일자",requestDto.getExceptValue()[z]));
+                }else {
+                    boolQueryBuilder.mustNot(QueryBuilders.wildcardQuery(requestDto.getExceptType()[z], requestDto.getExceptValue()[z] ));
+                }
+            }
+        }
+
+
+        // 법적 상태
+        if (requestDto.getStatusType() != null) {
+                boolQueryBuilder.should(QueryBuilders.termsQuery("법적상태", requestDto.getStatusType()));
+        }
+
+        if(Objects.equals(requestDto.getPatentType(), "특허")) {
+            boolQueryBuilder.must(QueryBuilders.matchQuery(
+                    "출원번호", "10"
+            ));
+        } else if(Objects.equals(requestDto.getPatentType(), "실용")) {
+            boolQueryBuilder.must(QueryBuilders.matchQuery(
+                    "출원번호", "20"
+            ));
+        }
+
+        searchSourceBuilder.size(20);
+        searchSourceBuilder.from((requestDto.getPage()-1) * 20);
+
+        searchSourceBuilder.highlighter(new HighlightBuilder().field("발명의명칭",230));
+        searchSourceBuilder.size(500);
+        searchSourceBuilder.query(boolQueryBuilder1);
+        searchSourceBuilder.postFilter(boolQueryBuilder1);
 
         searchRequest.source(searchSourceBuilder);
+
         List<Map<String, Object>> list = new ArrayList<>();
         SearchHits searchHits = client.search(searchRequest, RequestOptions.DEFAULT).getHits();
-        for (SearchHit hit : searchHits) {
+        searchHits.getSortFields();
+        for (
+                SearchHit hit : searchHits) {
             Map<String, Object> sourceMap = hit.getSourceAsMap();
             list.add(sourceMap);
         }
@@ -64,15 +165,24 @@ public class DocumentServiceImpl implements DocumentService {
 
     }
 
+    public BoolQueryBuilder nation (SearchRequestDto requestDto) {
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+        boolQueryBuilder.must(QueryBuilders.termsQuery("국가",requestDto.getCountry()));
+        return boolQueryBuilder;
+    }
 
-    @Override // 필드별 조회
-    public List<Map<String, Object>> getCustom(SearchRequestDto requestDto) throws IOException {
+    @Override // 해외 조회
+    public List<Map<String, Object>> getEnPatent(SearchRequestDto requestDto) throws IOException {
 
-        SearchRequest searchRequest = new SearchRequest(esProperties.getPatentIndexName());
+        SearchRequest searchRequest = new SearchRequest(esProperties.getenPatentIndexName(),esProperties.getjpPatentIndexName(),esProperties.getnotenPatentIndexName());
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
-        //제외방식 중첩?
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+
+        BoolQueryBuilder boolQueryBuilder1 = new BoolQueryBuilder();
+
+
+        //전체 검색
         for (int i = 0; i < requestDto.getContentType().length; i++) {
 
             // contentType=전체 contentValue=전기,반도체
@@ -83,21 +193,24 @@ public class DocumentServiceImpl implements DocumentService {
             boolean isPc = Objects.equals(requestDto.getContentType()[i], "IPC/CPC분류");
             boolean isYear = Objects.equals(requestDto.getContentType()[i], "연도");
 
+
             if (isNum) {
-                boolQueryBuilder.must(QueryBuilders.multiMatchQuery(
+                boolQueryBuilder1.must(QueryBuilders.multiMatchQuery(
                         requestDto.getContentValue()[i], "출원번호", "공개번호", "공고번호", "등록번호"));
             } else if (isAll) {
-                boolQueryBuilder.must(QueryBuilders.multiMatchQuery(
-                        "*" + requestDto.getContentValue()[i] + "*", "*").type("cross_fields"));
+                boolQueryBuilder.should(QueryBuilders.matchQuery("출원인",requestDto.getContentValue()[i]).operator(Operator.AND).fuzziness(Fuzziness.ONE))
+                                .should(QueryBuilders.matchQuery("요약",requestDto.getContentValue()[i]).boost(1.5f).fuzziness(Fuzziness.ONE).operator(Operator.AND))
+                                .should(QueryBuilders.matchQuery("발명의명칭",requestDto.getContentValue()[i]).boost(3.0f).operator(Operator.AND).fuzziness(Fuzziness.ONE))
+                                .should(QueryBuilders.multiMatchQuery(requestDto.getContentValue()[i],"IPC분류","CPC분류", "공개번호", "공고번호", "등록번호", "출원번호","출원일자").type("cross_fields"));
             }else if (isPc) {
-                boolQueryBuilder.must(QueryBuilders.moreLikeThisQuery(new String[]{"IPC분류", "CPC분류"},
+                boolQueryBuilder1.must(QueryBuilders.moreLikeThisQuery(new String[]{"IPC분류", "CPC분류"},
                         new String[]{requestDto.getContentValue()[i]}, null).minDocFreq(1).minTermFreq(1));
             }else if (isYear) {
-                boolQueryBuilder.must(QueryBuilders.wildcardQuery(
-                        "출원일자",requestDto.getContentValue()[i]+ ".*"));
+                boolQueryBuilder1.must(QueryBuilders.matchQuery(
+                        "출원일자",requestDto.getContentValue()[i]));
             } else {
-                boolQueryBuilder.must(QueryBuilders.wildcardQuery(
-                        requestDto.getContentType()[i], "*" + requestDto.getContentValue()[i] + "*"));
+                boolQueryBuilder1.must(QueryBuilders.matchQuery(
+                        requestDto.getContentType()[i],requestDto.getContentValue()[i]).operator(Operator.AND).fuzziness(Fuzziness.ONE));
             }
         }
 
@@ -117,37 +230,46 @@ public class DocumentServiceImpl implements DocumentService {
                     boolQueryBuilder.mustNot(QueryBuilders.multiMatchQuery(
                             requestDto.getExceptValue()[z], "IPC분류", "CPC분류"));
                 }else if (isYear) {
-                    boolQueryBuilder.mustNot(QueryBuilders.wildcardQuery(
-                            "출원일자",requestDto.getExceptValue()[z]+ ".*"));
+                    boolQueryBuilder.mustNot(QueryBuilders.matchQuery(
+                            "출원일자",requestDto.getExceptValue()[z]));
                 }else {
-                    boolQueryBuilder.mustNot(QueryBuilders.wildcardQuery(requestDto.getExceptType()[z], requestDto.getExceptValue()[z] ));
+                    boolQueryBuilder.mustNot(QueryBuilders.matchQuery(requestDto.getExceptType()[z], requestDto.getExceptValue()[z] ));
                 }
             }
         }
 
 
-        // 법적 상태
-        if (requestDto.getStatusType() != null) {
-            for (int k = 0; k < requestDto.getStatusType().length; k++) {
-                boolQueryBuilder.should(QueryBuilders.termQuery("법적상태", requestDto.getStatusType()[k]));
-            }
+        //정렬
+        if(Objects.equals(requestDto.getSortType(), "최신순")) {
+            searchSourceBuilder.sort("출원일자.keyword", SortOrder.DESC);
+        } else if (Objects.equals(requestDto.getSortType(), "오래된순")) {
+            searchSourceBuilder.sort("출원일자.keyword",SortOrder.ASC);
         }
 
-        if(Objects.equals(requestDto.getPatentType(), "특허")) {
-            boolQueryBuilder.must(QueryBuilders.wildcardQuery(
-                    "출원번호", "10-*"
-            ));
-        } else if(Objects.equals(requestDto.getPatentType(), "실용")) {
-            boolQueryBuilder.must(QueryBuilders.wildcardQuery(
-                    "출원번호", "20-*"
-            ));
-        }
 
-        searchSourceBuilder.size(500);
+
+        //페이지 네이션
+        searchSourceBuilder.size(20);
+        searchSourceBuilder.from((requestDto.getPage()-1) * 20);
+        searchSourceBuilder.explain(true);
+
+        //1차 쿼리
         searchSourceBuilder.query(boolQueryBuilder);
+
+        if(requestDto.getCountry() != null) {
+            //국가 선택
+            boolQueryBuilder1.must(QueryBuilders.termsQuery("국가",requestDto.getCountry()));
+        }
+
+        //1차 쿼리를 토대로한 2차쿼리
+        searchSourceBuilder.postFilter(boolQueryBuilder1);
+
         searchRequest.source(searchSourceBuilder);
         List<Map<String, Object>> list = new ArrayList<>();
         SearchHits searchHits = client.search(searchRequest, RequestOptions.DEFAULT).getHits();
+        System.out.println(searchHits.getTotalHits());
+
+
         for (
                 SearchHit hit : searchHits) {
             Map<String, Object> sourceMap = hit.getSourceAsMap();
@@ -157,149 +279,6 @@ public class DocumentServiceImpl implements DocumentService {
 
     }
 
-    // queryDSL 로 표현했을 때
-    // GET /students/_search
-    //{
-    //  "query": {
-    //    "bool": {
-    //      "should": [
-    //        {
-    //          "match": {
-    //            "name": "학생1"
-    //          }
-    //        },
-    //        {
-    //          "match": {
-    //            "name": "학생22"
-    //          }
-    //        }
-    //      ]
-    //    }
-    //  }
-    //}
-//    }
-
-    @Override
-    public IndexResponse createDocument() throws IOException {
-        IndexRequest request = new IndexRequest(esProperties.getPatentIndexName());
-        request.source(jsonBuilder()
-                .startObject()
-                .field(APPLICATION_NUMBER, "10326546421")
-                .field(APPLICATION_DATE, "2022.09.07")
-                .field(INVENTION_TITLE, "엘라스틱서치와 스프링부트 연동")
-                .field(APPLICANT, "희희")
-                .field(IPC_NUMBER, "A307 1022 5456")
-                .field(CPC_NUMBER, "G307 1022 5456")
-                .field(NOTICE_NUMBER, "65498463513")
-                .field(PUBLICATION_NUMBER, "45312154")
-                .field(REGISTRATION_NUMBER, "544534543453")
-                .field(LEGAL_STATUS, "공개")
-                .field(SUMMARY, "룰루랄라")
-                .endObject());
-        try {
-            return client.index(request, RequestOptions.DEFAULT);
-        } catch (ElasticsearchException e) {
-            if (e.status() == RestStatus.CONFLICT) {
-                log.error("문서 생성에 실패하였습니다.");
-            }
-        }
-        return null;
-    }
-
-    @Override //id 별 조회
-    public Map<String, Object> getDocument(String id) throws IOException {
-        GetRequest request = new GetRequest(esProperties.getPatentIndexName(), id);
-        GetResponse getResponse = client.get(request, RequestOptions.DEFAULT);
-        if (getResponse.isExists()) {
-            // 도큐먼트가 있는 경우
-            return getResponse.getSourceAsMap();
-        }
-        return null;
-    }
-
-
-//    @Override
-//    public DeleteResponse deleteDocument(String id) throws IOException {
-//        DeleteRequest deleteRequest = new DeleteRequest(esProperties.getStudentIndexName(), id);
-//        return client.delete(deleteRequest, RequestOptions.DEFAULT);
-//    }
-//
-//    @Override
-//    public UpdateResponse updateDocumentByScript(String id) throws IOException {
-//        UpdateRequest updateRequest = new UpdateRequest(esProperties.getStudentIndexName(), id);
-//
-//        // name 을 이름 수정으로 변경
-//        Map<String, Object> parameterMap = Collections.singletonMap(NAME, "이름수정");
-//        Script inline = new Script(ScriptType.INLINE, "painless", "ctx..name = params.name", parameterMap);
-//        // 이미 스크립트가 등록되어 있는 경우에는 ScriptType 을 Stored 로
-//        updateRequest.script(inline);
-//        // updateRequest.scriptedUpsert(true/false);
-//        // updateRequest.upsert(inline);
-//
-//        try {
-//            return client.update(updateRequest, RequestOptions.DEFAULT);
-//        } catch (ElasticsearchException e) {
-//            if (e.status() == RestStatus.NOT_FOUND) {
-//                System.out.println("업데이트 대상이 존재하지 않습니다. ");
-//            }
-//        }
-//        return null;
-//    }
-//
-//    @Override
-//    public UpdateResponse updateDocument(String id) throws IOException {
-//        // name 을 이름수정으로 변경
-//        XContentBuilder builder = jsonBuilder()
-//                .startObject()
-//                .field(NAME, "이름수정")
-//                .endObject();
-//
-//        UpdateRequest updateRequest = new UpdateRequest(esProperties.getStudentIndexName(), id).doc(builder);
-//        return client.update(updateRequest, RequestOptions.DEFAULT);
-//    }
-//
-//    @Override
-//    public UpdateResponse upsertDocument(String id) throws IOException {
-//        IndexRequest indexRequest = new IndexRequest(esProperties.getStudentIndexName()).source(jsonBuilder().startObject().field(NAME, "소소").endObject());
-//
-//        XContentBuilder xContentBuilder = jsonBuilder()
-//                .startObject()
-//                .field(CREATED_AT, new Date())
-//                .endObject();
-//
-//        UpdateRequest updateRequest = new UpdateRequest(esProperties.getStudentIndexName(), id).doc(xContentBuilder).upsert(indexRequest);
-//        return client.update(updateRequest, RequestOptions.DEFAULT);
-//    }
-//
-//    @Override
-//    public BulkResponse createDocumentBulk() throws IOException {
-//        BulkRequest request = new BulkRequest();
-//        request.add(new IndexRequest(esProperties.getStudentIndexName()).source(XContentType.JSON, NAME, "테스트1"));
-//        request.add(new IndexRequest(esProperties.getStudentIndexName()).source(XContentType.JSON, NAME, "테스트2"));
-//        request.add(new IndexRequest(esProperties.getStudentIndexName()).source(XContentType.JSON, NAME, "테스트3"));
-//        return client.bulk(request, RequestOptions.DEFAULT);
-
-//    @Override // 필드별 조회
-//    public List<Map<String,Object>> getCustom1(SearchRequestDto requestDto) throws IOException {
-//        d
-//        SearchRequest searchRequest = new SearchRequest(esProperties.getPatentIndexName());
-//        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-//        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
-//        boolQueryBuilder.should(QueryBuilders.wildcardQuery(requestDto.getType(), "*" + requestDto.getContent() + "*"));
-//
-//        searchSourceBuilder.size(500);
-//
-//        searchSourceBuilder.query(boolQueryBuilder);
-//        searchRequest.source(searchSourceBuilder);
-//        List<Map<String,Object>> list = new ArrayList<>();
-//        SearchHits searchHits = client.search(searchRequest, RequestOptions.DEFAULT).getHits();
-//        for(SearchHit hit : searchHits) {
-//            Map<String, Object> sourceMap = hit.getSourceAsMap();
-//            list.add(sourceMap);
-//        }
-//        return list;
-//
-//    }
 
 
 }


### PR DESCRIPTION
- 해외 특허 인덱스 검색기능을 구현하였습니다.

1. 해외특허 버튼 클릭

2. 검색어 입력
- 전체, 제목, 요약, 출원인 등을 드롭다운에서 선택 후 검색합니다.
- “전체”, “발명의명칭(제목)”, “요약”, “번호정보("출원번호", "공개번호", "공고번호", "등록번호")” , “연도 ” “IPC/CPC분류”, “출원인”

3. 검색 결과 출력
- 검색 결과 내에서 반드시 포함, 제외할 부분을 입력하여 검색합니다 (재검색 포함).
- 체크박스로 국가 필터를 선택할 수 있습니다.